### PR TITLE
Child window sequence

### DIFF
--- a/Osprey/Form1.cs
+++ b/Osprey/Form1.cs
@@ -238,12 +238,7 @@ namespace CodeLessTraveled.Osprey
 
                     m_CurrentXmlFilename = m_DefaultOspreyDataXml;
 
-                //  FileScopeData fsd =  util_GetFileScopeSettings(m_CurrentXml);
-
-                if (null == m_CurrentXml)
-                {
-                    string x = "";
-                }
+           
                     
                     m_UI_STATE_HasFiles = true;
                 }
@@ -264,6 +259,10 @@ namespace CodeLessTraveled.Osprey
 
             
             Menu_FolderGroup_ComboBox_0.Text = util_GetLastViewedFolderTeam();  // !set m_CurrentFolderGroup[m_idxFTeamDisplayName] by reading the current xml.
+
+            
+            FileScopeData fsd =  util_GetFileScopeSettings(m_CurrentXml);
+
 
         }
 

--- a/Osprey/Form1.cs
+++ b/Osprey/Form1.cs
@@ -238,9 +238,13 @@ namespace CodeLessTraveled.Osprey
 
                     m_CurrentXmlFilename = m_DefaultOspreyDataXml;
 
-                    FileScopeData fsd =  util_GetFileScopeSettings(m_CurrentXml);
+                //  FileScopeData fsd =  util_GetFileScopeSettings(m_CurrentXml);
 
-
+                if (null == m_CurrentXml)
+                {
+                    string x = "";
+                }
+                    
                     m_UI_STATE_HasFiles = true;
                 }
                 #endregion


### PR DESCRIPTION
Bug fix related to the initial XmlRepository folder not being fully created before the Form_Load attempts to use it. Just needed to move that line to the bottom of the Form_Load routine to ensure the default Xml file was created and loaded into the XmlDocument member variable.
Faster configuration for folder child window sequence. Child windows automatically, resize with the parent window. Color indicator associated with each configuration xml file so each Osprey instance has visual color indicator for the file loaded. So for example your Development environment folder groups are configured for a "green" indicator while a second instance of Osprey for Production folder groups provide a "red" indicator. Easy to compare folders between environments without confusing the two environments.

Help files have not been updated yet.
